### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/adr.md
+++ b/.github/ISSUE_TEMPLATE/adr.md
@@ -1,0 +1,32 @@
+---
+name: ADR
+about: Suggest/record an architecture decision record
+title: ''
+labels: ADR
+assignees: ''
+
+---
+
+# Title
+
+## Status
+
+> What is the status, such as proposed, discussed, accepted, rejected, deprecated, superseded, etc.?
+
+## Context
+
+> What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+> What is the change that we're proposing and/or doing?
+
+## Consequences
+
+> What becomes easier or more difficult to do because of this change?
+
+Easier:
+* 
+
+More Difficult:
+*

--- a/.github/ISSUE_TEMPLATE/issue-user-story.md
+++ b/.github/ISSUE_TEMPLATE/issue-user-story.md
@@ -1,0 +1,30 @@
+---
+name: Issue/user story
+about: Report a bug, suggest a feature
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Expected behavior
+
+* As a paas-templates operator | cf user | marketplace user | paas-templates author | paas-templates maintainer
+* In order to 
+* I need 
+
+### Observed behavior
+ 
+### Affected releases
+
+* x.y
+* earlier versions
+
+<!--
+### Traces and logs
+
+Remember this is a public repo. DON'T leak credentials or Orange internal URLs. 
+Automation may be applied in the future. 
+
+* [ ] I have reviewed provided traces against secrets (credentials, internal URLs) that should not be leake, manually of using some tools such as [truffle-hog file:///user/dxa4481/codeprojects/mytraces.txt](https://github.com/dxa4481/truffleHog#truffle-hog)
+ -->


### PR DESCRIPTION
Issue templates using github ui as instructed in https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

Imported legacy issue_template.md